### PR TITLE
Fix property validation accepting null values and mixed-category arrays (#10)

### DIFF
--- a/bhopengraph/Properties.py
+++ b/bhopengraph/Properties.py
@@ -4,7 +4,7 @@
 # Author             : Remi Gascou (@podalirius_)
 # Date created       : 12 Aug 2025
 
-# https://bloodhound.specterops.io/opengraph/schema#node-json
+# https://bloodhound.specterops.io/opengraph/developer/nodes
 PROPERTIES_SCHEMA = {
     "type": ["object", "null"],
     "description": "A key-value map of node attributes. Values must not be objects. If a value is an array, it must contain only primitive types (e.g., strings, numbers, booleans) and must be homogeneous (all items must be of the same type).",
@@ -13,6 +13,36 @@ PROPERTIES_SCHEMA = {
         "items": {"not": {"type": "object"}},
     },
 }
+
+
+def primitive_category(value) -> str:
+    """
+    Classify a value into one of the OpenGraph primitive categories.
+
+    The BloodHound OpenGraph schema recognizes three primitive categories for
+    property values: "string", "number", and "boolean". This helper returns the
+    matching category, or an empty string when the value is None or not a
+    primitive (e.g. an object, list, or callable).
+
+    Note: ``bool`` is checked before ``int`` because in Python ``bool`` is a
+    subclass of ``int``; without this order ``True``/``False`` would be
+    misclassified as numbers.
+
+    Source: https://bloodhound.specterops.io/opengraph/developer/nodes
+
+    Args:
+      - value: The value to classify
+
+    Returns:
+      - str: "string", "number", "boolean", or "" if not a primitive
+    """
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    return ""
 
 
 class Properties(object):
@@ -38,13 +68,15 @@ class Properties(object):
 
         Args:
           - key (str): Property name
-          - value: Property value (must be primitive type: str, int, float, bool, None, list)
+          - value: Property value (must be a primitive type: str, int, float,
+            bool, or a homogeneous list of those). None is not a valid value.
         """
         if self.is_valid_property_value(value):
             self._properties[key] = value
         else:
             raise ValueError(
-                f"Property value must be a primitive type (str, int, float, bool, None, list), got {type(value)}"
+                f"Property value must be a primitive type (str, int, float, bool) "
+                f"or a homogeneous list of primitives, got {type(value)}"
             )
 
     def get_property(self, key: str, default=None):
@@ -107,7 +139,8 @@ class Properties(object):
         for key, value in self._properties.items():
             if not self.is_valid_property_value(value):
                 errors.append(
-                    f"Property '{key}' has invalid value type '{type(value)}' not in (str, int, float, bool, None, list)"
+                    f"Property '{key}' has invalid value type '{type(value)}'; "
+                    f"expected a primitive (str, int, float, bool) or a homogeneous list of primitives"
                 )
 
         return len(errors) == 0, errors
@@ -116,9 +149,16 @@ class Properties(object):
         """
         Validate a single property value according to OpenGraph schema rules.
 
-        Properties must be primitive types or arrays of primitive types.
-        Nested objects and arrays of objects are not allowed.
-        Arrays must be homogeneous (e.g. all strings or all numbers).
+        The BloodHound OpenGraph schema restricts a property value to a single
+        primitive (string, number, or boolean) or a homogeneous array of
+        primitives. None, nested objects, arrays of objects, and arrays mixing
+        primitive categories are not valid.
+
+        Note: ``bool`` and the numeric types are treated as distinct categories,
+        so a list such as ``[1, True]`` is rejected as non-homogeneous even
+        though ``bool`` is a subclass of ``int`` in Python.
+
+        Source: https://bloodhound.specterops.io/opengraph/developer/nodes
 
         Args:
           - value: The property value to validate
@@ -126,37 +166,26 @@ class Properties(object):
         Returns:
           - bool: True if valid, False otherwise
         """
-        # Check if value is None (allowed)
+        # None is not a valid property value per the OpenGraph schema.
         if value is None:
-            return True
+            return False
 
-        # Check if value is a primitive type
-        if isinstance(value, (str, int, float, bool)):
-            return True
-
-        # Check if value is an array
+        # Lists must be homogeneous sequences of primitives.
         if isinstance(value, list):
-            if not value:  # Empty array is valid
-                return True
-
-            # Check if all items are of the same primitive type
-            first_type = type(value[0])
-            if first_type not in (str, int, float, bool):
-                return False
-
-            # Check that all items are the same type and not nested objects/arrays
+            category = ""
             for item in value:
-                # Reject nested objects (dict) or nested arrays (list)
-                if isinstance(item, (dict, list)):
+                item_category = primitive_category(item)
+                if item_category == "":
                     return False
-                # Reject items that are not the same type as the first item
-                if not isinstance(item, first_type):
+                if category == "":
+                    category = item_category
+                elif item_category != category:
                     return False
-
+            # An empty list is valid.
             return True
 
-        # Objects (dict) are not allowed
-        return False
+        # Single values must be a primitive (string, number, or boolean).
+        return primitive_category(value) != ""
 
     def to_dict(self) -> dict:
         """

--- a/bhopengraph/tests/test_Properties.py
+++ b/bhopengraph/tests/test_Properties.py
@@ -47,10 +47,13 @@ class TestProperties(unittest.TestCase):
         self.props.set_property("enabled", False)
         self.assertEqual(self.props.get_property("enabled"), False)
 
-    def test_set_property_none(self):
-        """Test setting a None property."""
-        self.props.set_property("optional", None)
-        self.assertIsNone(self.props.get_property("optional"))
+    def test_set_property_none_raises_error(self):
+        """Test that setting a None property raises ValueError.
+
+        Per the OpenGraph schema, null is not a valid property value.
+        """
+        with self.assertRaises(ValueError):
+            self.props.set_property("optional", None)
 
     def test_set_property_list(self):
         """Test setting a list property."""
@@ -198,8 +201,8 @@ class TestProperties(unittest.TestCase):
         self.assertTrue(self.props.is_valid_property_value(True))
 
     def test_is_valid_property_value_none(self):
-        """Test that None values are valid."""
-        self.assertTrue(self.props.is_valid_property_value(None))
+        """Test that None values are invalid per the OpenGraph schema."""
+        self.assertFalse(self.props.is_valid_property_value(None))
 
     def test_is_valid_property_value_list(self):
         """Test that list values are valid."""
@@ -227,9 +230,6 @@ class TestProperties(unittest.TestCase):
 
         self.props.set_property("test", True)
         self.assertEqual(self.props.get_property("test"), True)
-
-        self.props.set_property("test", None)
-        self.assertIsNone(self.props.get_property("test"))
 
         # Valid homogeneous arrays
         self.props.set_property("test", [])
@@ -311,7 +311,6 @@ class TestProperties(unittest.TestCase):
         """Test is_valid_property_value with comprehensive Python types."""
         # Valid types
         valid_types = [
-            None,
             "string",
             "",
             "unicode_string_ñáéíóú",
@@ -361,6 +360,7 @@ class TestProperties(unittest.TestCase):
     def test_is_valid_property_value_invalid_types(self):
         """Test is_valid_property_value with invalid Python types."""
         invalid_types = [
+            None,
             {"dict": "not allowed"},
             {"nested": {"dict": "not allowed"}},
             {"empty": {}},
@@ -512,7 +512,6 @@ class TestProperties(unittest.TestCase):
             int_prop=42,
             float_prop=3.14,
             bool_prop=True,
-            none_prop=None,
             empty_list_prop=[],
             string_list_prop=["a", "b", "c"],
             int_list_prop=[1, 2, 3],


### PR DESCRIPTION
### Linked Issue
Closes #10

### Root Cause
`Properties.is_valid_property_value()` whitelisted `None` and validated array homogeneity with `isinstance(item, type(value[0]))`. The OpenGraph schema does not permit `null` property values, and because `bool` is a subclass of `int` in Python, the `isinstance` check conflated the `number` and `boolean` primitive categories. As a result an array such as `[1, True]` was accepted while the order-reversed `[True, 1]` was rejected.

### Fix Description
`None` is now rejected. Array validation is rewritten around a `primitive_category()` helper that maps each value to exactly one of `string` / `number` / `boolean` (checking `bool` before `int` so booleans are not treated as numbers); an array is valid only when every element shares the same category. Empty arrays remain valid. This mirrors the validation now enforced by the Go implementation (`gopengraph`).

### How Verified
Before, on the prior code: `is_valid_property_value(None)` returned `True`, `[1, True]` returned `True`, `[True, 1]` returned `False`.
After: `None` is rejected, and both `[1, True]` and `[True, 1]` are rejected; homogeneous arrays (`["a","b"]`, `[1,2,3]`, `[True,False]`, `[]`) remain valid. Verified by the test suite below.

### Test Coverage
**Added / Updated:** `bhopengraph/tests/test_Properties.py`
- `test_is_valid_property_value_none` now asserts `None` is invalid.
- `test_set_property_none_raises_error` asserts setting `None` raises `ValueError`.
- `None` added to the `invalid_types` set; removed from `valid_types` and from the comprehensive set/validate fixtures.

### Scope of Change
- **Files changed:** `bhopengraph/Properties.py`, `bhopengraph/tests/test_Properties.py`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Behavioral change: callers that previously stored a property value of `None` will now receive a `ValueError`. This is the intended schema-conforming behavior; callers should omit the property instead of setting it to `None`. Local and self-contained; safe to merge.
