### PR TITLE
Add edge endpoint match_by strategies and edge kind validation (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,36 @@ This gives us the following [Minimal Working JSON](https://bloodhound.specterops
 }
 ```
 
+### Edge endpoint matching strategies
+
+By default, edge endpoints are resolved by node `id`, which is the preferred and fastest strategy. The OpenGraph schema also supports resolving an endpoint by `name` (deprecated, but still accepted) or dynamically by one or more `property` matchers. Use these when you need to attach an edge to a node you did not emit yourself (for example, an existing AD/AZ object collected by SharpHound), and always set a `kind` filter to avoid attaching the edge to the wrong node on a name collision.
+
+```py
+from bhopengraph.Edge import Edge, Endpoint, PropertyMatcher
+
+# Match the end node by name, constrained to the Computer kind
+edge_by_name = Edge.with_endpoints(
+    start=Endpoint.by_id("user-1234"),
+    end=Endpoint.by_name("DC01.CORP.COM", kind="Computer"),
+    kind="Reaches",
+)
+
+# Match the start node dynamically by property matchers (AND-combined)
+edge_by_property = Edge.with_endpoints(
+    start=Endpoint.by_property(
+        [PropertyMatcher(key="username", value="alice.smith")],
+        kind="User",
+    ),
+    end=Endpoint.by_id("server-5678"),
+    kind="CustomRelationship",
+)
+```
+
+The simple `Edge(start_node, end_node, kind, ...)` constructor still works for `id`- and `name`-matched endpoints via its `start_match_by` / `end_match_by` arguments.
+
+> [!NOTE]
+> Edge `kind` values must match `^[A-Za-z0-9_]+$` (letters, digits, underscores only) and must not use the reserved `tag_` prefix. Node `kinds` are limited to a maximum of 3 entries, and property values must be primitives (string, number, boolean) or homogeneous arrays of primitives — `null` is not a valid property value.
+
 ## Contributing
 
 Pull requests are welcome. Feel free to open an issue if you want to add other features.

--- a/bhopengraph/Edge.py
+++ b/bhopengraph/Edge.py
@@ -4,12 +4,69 @@
 # Author             : Remi Gascou (@podalirius_)
 # Date created       : 12 Aug 2025
 
-from bhopengraph.Properties import Properties
+import re
 
-# https://bloodhound.specterops.io/opengraph/schema#edge-json
+from bhopengraph.Properties import Properties, primitive_category
+
+# match_by strategies for resolving an edge endpoint to a node, as defined by
+# the BloodHound OpenGraph edge schema.
+#
+# Source: https://bloodhound.specterops.io/opengraph/developer/edges
+
+# MATCH_BY_ID resolves an endpoint by unique node id. This is the default.
+MATCH_BY_ID = "id"
+# MATCH_BY_NAME resolves an endpoint by name. Deprecated in BloodHound but still
+# accepted; supported here so payloads using it can round-trip.
+MATCH_BY_NAME = "name"
+# MATCH_BY_PROPERTY resolves an endpoint dynamically from one or more property
+# matchers evaluated at ingestion time.
+MATCH_BY_PROPERTY = "property"
+
+# The set of match strategies supported by the OpenGraph edge schema.
+MATCH_BY_STRATEGIES = (MATCH_BY_ID, MATCH_BY_NAME, MATCH_BY_PROPERTY)
+
+# edge_kind_pattern is the set of characters the OpenGraph schema allows in an
+# edge kind: uppercase letters, lowercase letters, digits, and underscores.
+#
+# Source: https://bloodhound.specterops.io/opengraph/developer/edges
+EDGE_KIND_PATTERN = re.compile(r"^[A-Za-z0-9_]+$")
+
+# RESERVED_KIND_PREFIX is reserved by BloodHound in any letter case and must not
+# be used for custom edge kinds.
+RESERVED_KIND_PREFIX = "tag_"
+
+
+def validate_kind(kind: str):
+    """
+    Validate an OpenGraph edge kind.
+
+    A valid edge kind is non-empty, matches ``^[A-Za-z0-9_]+$`` (no spaces,
+    dashes, or punctuation), and does not use the reserved ``tag_`` prefix (in
+    any letter case).
+
+    Source: https://bloodhound.specterops.io/opengraph/developer/edges
+
+    Args:
+      - kind (str): The edge kind to validate
+
+    Returns:
+      - str | None: An error message if the kind is invalid, otherwise None
+    """
+    if not kind:
+        return "Edge kind cannot be empty"
+    if not isinstance(kind, str):
+        return "Edge kind must be a string"
+    if not EDGE_KIND_PATTERN.match(kind):
+        return f"Edge kind '{kind}' must match {EDGE_KIND_PATTERN.pattern}"
+    if kind[: len(RESERVED_KIND_PREFIX)].lower() == RESERVED_KIND_PREFIX:
+        return f"Edge kind '{kind}' must not use the reserved '{RESERVED_KIND_PREFIX}' prefix"
+    return None
+
+
+# https://bloodhound.specterops.io/opengraph/developer/edges
 EDGE_SCHEMA = {
     "title": "Generic Ingest Edge",
-    "description": "Defines an edge between two nodes in a generic graph ingestion system. Each edge specifies a start and end node using either a unique identifier (id) or a name-based lookup. A kind is required to indicate the relationship type. Optional properties may include custom attributes. You may optionally constrain the start or end node to a specific kind using the kind field inside each reference.",
+    "description": "Defines an edge between two nodes in a generic graph ingestion system. Each edge specifies a start and end node, resolved either by unique identifier (id), by name, or dynamically through property matchers. A kind is required to indicate the relationship type. Optional properties may include custom attributes. You may optionally constrain the start or end node to a specific kind using the kind field inside each reference.",
     "type": "object",
     "properties": {
         "start": {
@@ -17,40 +74,64 @@ EDGE_SCHEMA = {
             "properties": {
                 "match_by": {
                     "type": "string",
-                    "enum": ["id", "name"],
+                    "enum": ["id", "name", "property"],
                     "default": "id",
-                    "description": "Whether to match the start node by its unique object ID or by its name property.",
+                    "description": "How to resolve the start node: by its unique object ID, by its name property, or dynamically by property matchers.",
                 },
                 "value": {
                     "type": "string",
-                    "description": "The value used for matching — either an object ID or a name, depending on match_by.",
+                    "description": "The value used for matching — either an object ID or a name, depending on match_by. Absent when match_by is 'property'.",
+                },
+                "property_matchers": {
+                    "type": "array",
+                    "description": "Property match criteria, used when match_by is 'property'. Matchers are AND-combined.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "key": {"type": "string"},
+                            "operator": {"type": "string"},
+                            "value": {},
+                        },
+                        "required": ["key"],
+                    },
                 },
                 "kind": {
                     "type": "string",
                     "description": "Optional kind filter; the referenced node must have this kind.",
                 },
             },
-            "required": ["value"],
         },
         "end": {
             "type": "object",
             "properties": {
                 "match_by": {
                     "type": "string",
-                    "enum": ["id", "name"],
+                    "enum": ["id", "name", "property"],
                     "default": "id",
-                    "description": "Whether to match the end node by its unique object ID or by its name property.",
+                    "description": "How to resolve the end node: by its unique object ID, by its name property, or dynamically by property matchers.",
                 },
                 "value": {
                     "type": "string",
-                    "description": "The value used for matching — either an object ID or a name, depending on match_by.",
+                    "description": "The value used for matching — either an object ID or a name, depending on match_by. Absent when match_by is 'property'.",
+                },
+                "property_matchers": {
+                    "type": "array",
+                    "description": "Property match criteria, used when match_by is 'property'. Matchers are AND-combined.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "key": {"type": "string"},
+                            "operator": {"type": "string"},
+                            "value": {},
+                        },
+                        "required": ["key"],
+                    },
                 },
                 "kind": {
                     "type": "string",
                     "description": "Optional kind filter; the referenced node must have this kind.",
                 },
             },
-            "required": ["value"],
         },
         "kind": {"type": "string"},
         "properties": {
@@ -77,31 +158,268 @@ EDGE_SCHEMA = {
             "properties": {"via": "SMB", "sensitive": True},
         },
         {
-            "start": {"value": "admin-1"},
-            "end": {"value": "domain-controller-9"},
-            "kind": "AdminTo",
-            "properties": {"reason": "elevated_permissions", "confirmed": False},
-        },
-        {
-            "start": {"match_by": "name", "value": "Printer-007"},
-            "end": {"match_by": "id", "value": "network-42"},
-            "kind": "ConnectedTo",
-            "properties": None,
+            "start": {
+                "match_by": "property",
+                "property_matchers": [
+                    {"key": "username", "operator": "equals", "value": "alice.smith"}
+                ],
+                "kind": "User",
+            },
+            "end": {"match_by": "id", "value": "server-1"},
+            "kind": "CustomRelationship",
         },
     ],
 }
+
+
+class PropertyMatcher(object):
+    """
+    A single property-based match criterion, used when an edge endpoint's match
+    strategy is ``property``.
+
+    Matcher values are restricted to primitives (string, number, boolean) by the
+    schema. Multiple matchers on an endpoint are AND-combined. Only the
+    ``equals`` operator is currently supported by BloodHound.
+
+    Source: https://bloodhound.specterops.io/opengraph/developer/edges
+    """
+
+    def __init__(self, key: str, value, operator: str = "equals"):
+        """
+        Initialize a PropertyMatcher.
+
+        Args:
+          - key (str): The property name to match against
+          - value: The value to compare against (must be a primitive)
+          - operator (str): The comparison operator (defaults to "equals")
+        """
+        self.key = key
+        self.operator = operator
+        self.value = value
+
+    def validate(self) -> tuple:
+        """
+        Validate the property matcher.
+
+        Returns:
+          - tuple[bool, list[str]]: (is_valid, list_of_errors)
+        """
+        errors = []
+        if not self.key:
+            errors.append("Property matcher requires a non-empty key")
+        elif not isinstance(self.key, str):
+            errors.append("Property matcher key must be a string")
+        if self.value is not None and primitive_category(self.value) == "":
+            errors.append("Property matcher value must be a primitive")
+        return len(errors) == 0, errors
+
+    def to_dict(self) -> dict:
+        """
+        Convert the matcher to a dictionary for JSON serialization.
+
+        Returns:
+          - dict: Matcher as {"key": ..., "operator": ..., "value": ...}
+        """
+        return {"key": self.key, "operator": self.operator, "value": self.value}
+
+    def _signature(self) -> tuple:
+        return (self.key, self.operator, self.value)
+
+    def __eq__(self, other):
+        if isinstance(other, PropertyMatcher):
+            return self._signature() == other._signature()
+        return False
+
+    def __hash__(self):
+        return hash(self._signature())
+
+    def __repr__(self) -> str:
+        return f"PropertyMatcher(key='{self.key}', operator='{self.operator}', value={self.value!r})"
+
+
+class Endpoint(object):
+    """
+    Identifies the start or end of an edge and describes how BloodHound should
+    resolve it to a node.
+
+    An endpoint can be resolved by node id (the default and preferred strategy),
+    by name (deprecated but still accepted), or dynamically by property matchers.
+    An optional ``kind`` filter constrains the matched node to a specific kind;
+    it is strongly recommended when matching by name or property to avoid
+    attaching the edge to the wrong node on a name collision.
+
+    Source: https://bloodhound.specterops.io/opengraph/developer/edges
+    """
+
+    def __init__(
+        self,
+        match_by: str = MATCH_BY_ID,
+        value: str = "",
+        kind: str = "",
+        property_matchers: list = None,
+    ):
+        """
+        Initialize an Endpoint.
+
+        Prefer the ``by_id``, ``by_name``, and ``by_property`` constructors for
+        clarity.
+
+        Args:
+          - match_by (str): One of "id", "name", or "property"
+          - value (str): The id or name value (for "id"/"name" strategies)
+          - kind (str): Optional kind filter
+          - property_matchers (list): PropertyMatcher list (for "property")
+        """
+        self.match_by = match_by or MATCH_BY_ID
+        self.value = value or ""
+        self.kind = kind or ""
+        self.property_matchers = list(property_matchers) if property_matchers else []
+
+    @classmethod
+    def by_id(cls, value: str) -> "Endpoint":
+        """Create an endpoint resolved by node id."""
+        return cls(match_by=MATCH_BY_ID, value=value)
+
+    @classmethod
+    def by_name(cls, value: str, kind: str = "") -> "Endpoint":
+        """
+        Create an endpoint resolved by name. ``kind`` is optional and
+        disambiguates the kind of the target node.
+        """
+        return cls(match_by=MATCH_BY_NAME, value=value, kind=kind)
+
+    @classmethod
+    def by_property(cls, property_matchers: list, kind: str = "") -> "Endpoint":
+        """
+        Create an endpoint resolved by property matchers. ``kind`` is optional.
+        """
+        return cls(
+            match_by=MATCH_BY_PROPERTY, kind=kind, property_matchers=property_matchers
+        )
+
+    def validate(self) -> tuple:
+        """
+        Validate the endpoint for internal consistency with its match strategy.
+
+        Returns:
+          - tuple[bool, list[str]]: (is_valid, list_of_errors)
+        """
+        errors = []
+        if self.match_by in (MATCH_BY_ID, MATCH_BY_NAME):
+            if not self.value:
+                errors.append(
+                    f"Endpoint with match_by '{self.match_by}' requires a non-empty value"
+                )
+            elif not isinstance(self.value, str):
+                errors.append("Endpoint value must be a string")
+        elif self.match_by == MATCH_BY_PROPERTY:
+            if not self.property_matchers:
+                errors.append(
+                    "Endpoint with match_by 'property' requires at least one property matcher"
+                )
+            for matcher in self.property_matchers:
+                if not isinstance(matcher, PropertyMatcher):
+                    errors.append("Property matchers must be PropertyMatcher instances")
+                    continue
+                is_matcher_valid, matcher_errors = matcher.validate()
+                if not is_matcher_valid:
+                    errors.extend(matcher_errors)
+        else:
+            errors.append(f"Unsupported match_by '{self.match_by}'")
+        return len(errors) == 0, errors
+
+    def to_dict(self) -> dict:
+        """
+        Convert the endpoint to a dictionary for JSON serialization, matching the
+        shape BloodHound expects for the endpoint's match strategy.
+
+        Returns:
+          - dict: Endpoint as a dictionary
+        """
+        endpoint_dict = {"match_by": self.match_by}
+
+        if self.match_by == MATCH_BY_PROPERTY:
+            endpoint_dict["property_matchers"] = [
+                matcher.to_dict() for matcher in self.property_matchers
+            ]
+        else:
+            endpoint_dict["value"] = self.value
+
+        if self.kind:
+            endpoint_dict["kind"] = self.kind
+
+        return endpoint_dict
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Endpoint":
+        """
+        Create an Endpoint from a dictionary (typically parsed from JSON).
+
+        Defaults to id matching when ``match_by`` is omitted.
+
+        Args:
+          - data (dict): Dictionary containing endpoint data
+
+        Returns:
+          - Endpoint: Endpoint instance
+        """
+        match_by = data.get("match_by") or MATCH_BY_ID
+        kind = data.get("kind", "")
+
+        if match_by == MATCH_BY_PROPERTY:
+            matchers = []
+            for matcher_data in data.get("property_matchers", []):
+                matchers.append(
+                    PropertyMatcher(
+                        key=matcher_data.get("key"),
+                        value=matcher_data.get("value"),
+                        operator=matcher_data.get("operator", "equals"),
+                    )
+                )
+            return cls.by_property(matchers, kind)
+
+        return cls(match_by=match_by, value=data.get("value", ""), kind=kind)
+
+    def signature(self) -> tuple:
+        """
+        Return a hashable signature uniquely identifying this endpoint, used for
+        edge equality and deduplication.
+
+        Returns:
+          - tuple: A hashable representation of the endpoint
+        """
+        return (
+            self.match_by,
+            self.value,
+            self.kind,
+            tuple(matcher._signature() for matcher in self.property_matchers),
+        )
+
+    def __eq__(self, other):
+        if isinstance(other, Endpoint):
+            return self.signature() == other.signature()
+        return False
+
+    def __hash__(self):
+        return hash(self.signature())
+
+    def __repr__(self) -> str:
+        if self.match_by == MATCH_BY_PROPERTY:
+            return f"Endpoint(match_by='{self.match_by}', kind='{self.kind}', property_matchers={self.property_matchers})"
+        return f"Endpoint(match_by='{self.match_by}', value='{self.value}', kind='{self.kind}')"
 
 
 class Edge(object):
     """
     Edge class representing a directed edge in the OpenGraph.
 
-    Follows BloodHound OpenGraph schema requirements with start/end nodes, kind, and properties.
-    All edges are directed and one-way as per BloodHound requirements.
+    Follows BloodHound OpenGraph schema requirements with start/end endpoints,
+    kind, and properties. All edges are directed and one-way as per BloodHound
+    requirements.
 
     Sources:
-    - https://bloodhound.specterops.io/opengraph/schema#edges
-    - https://bloodhound.specterops.io/opengraph/schema#minimal-working-json
+    - https://bloodhound.specterops.io/opengraph/developer/edges
+    - https://bloodhound.specterops.io/opengraph/developer/graph-data
     """
 
     def __init__(
@@ -110,32 +428,115 @@ class Edge(object):
         end_node: str,
         kind: str,
         properties: Properties = None,
-        start_match_by: str = "id",
-        end_match_by: str = "id",
+        start_match_by: str = MATCH_BY_ID,
+        end_match_by: str = MATCH_BY_ID,
     ):
         """
-        Initialize an Edge.
+        Initialize an Edge whose endpoints are resolved by id or name.
+
+        For property-based matching or kind filters on endpoints, use the
+        ``with_endpoints`` constructor.
 
         Args:
-          - start_node (str): ID of the source node
-          - end_node (str): ID of the destination node
+          - start_node (str): Value of the source endpoint (id or name)
+          - end_node (str): Value of the destination endpoint (id or name)
           - kind (str): Type/class of the edge relationship
           - properties (Properties): Edge properties
+          - start_match_by (str): "id" (default) or "name"
+          - end_match_by (str): "id" (default) or "name"
         """
         if not start_node:
             raise ValueError("Start node ID cannot be empty")
         if not end_node:
             raise ValueError("End node ID cannot be empty")
-        if not kind:
-            raise ValueError("Edge kind cannot be empty")
 
-        self.start_node = start_node
-        self.end_node = end_node
+        self._init_common(
+            Endpoint(match_by=start_match_by, value=start_node),
+            Endpoint(match_by=end_match_by, value=end_node),
+            kind,
+            properties,
+        )
+
+    @classmethod
+    def with_endpoints(
+        cls,
+        start: Endpoint,
+        end: Endpoint,
+        kind: str,
+        properties: Properties = None,
+    ) -> "Edge":
+        """
+        Create an Edge from explicit endpoints, allowing any match strategy for
+        either end (id, name, or property).
+
+        Args:
+          - start (Endpoint): The source endpoint
+          - end (Endpoint): The destination endpoint
+          - kind (str): Type/class of the edge relationship
+          - properties (Properties): Edge properties
+
+        Returns:
+          - Edge: A new Edge instance
+        """
+        obj = cls.__new__(cls)
+        obj._init_common(start, end, kind, properties)
+        return obj
+
+    def _init_common(
+        self, start: Endpoint, end: Endpoint, kind: str, properties: Properties
+    ):
+        kind_error = validate_kind(kind)
+        if kind_error:
+            raise ValueError(kind_error)
+
+        is_start_valid, start_errors = start.validate()
+        if not is_start_valid:
+            raise ValueError(f"Invalid start endpoint: {'; '.join(start_errors)}")
+
+        is_end_valid, end_errors = end.validate()
+        if not is_end_valid:
+            raise ValueError(f"Invalid end endpoint: {'; '.join(end_errors)}")
+
+        self.start = start
+        self.end = end
         self.kind = kind
         self.properties = properties or Properties()
 
-        self.start_match_by = start_match_by
-        self.end_match_by = end_match_by
+    # Backward-compatible accessors for the pre-endpoint Edge API. These expose
+    # the underlying endpoints so existing callers using start_node / end_node /
+    # start_match_by / end_match_by continue to work unchanged.
+
+    @property
+    def start_node(self) -> str:
+        return self.start.value
+
+    @start_node.setter
+    def start_node(self, value: str):
+        self.start.value = value
+
+    @property
+    def end_node(self) -> str:
+        return self.end.value
+
+    @end_node.setter
+    def end_node(self, value: str):
+        self.end.value = value
+
+    @property
+    def start_match_by(self) -> str:
+        return self.start.match_by
+
+    @start_match_by.setter
+    def start_match_by(self, value: str):
+        self.start.match_by = value
+
+    @property
+    def end_match_by(self) -> str:
+        return self.end.match_by
+
+    @end_match_by.setter
+    def end_match_by(self, value: str):
+        self.end.match_by = value
 
     def set_property(self, key: str, value):
         """
@@ -178,8 +579,8 @@ class Edge(object):
         """
         edge_dict = {
             "kind": self.kind,
-            "start": {"value": self.start_node, "match_by": self.start_match_by},
-            "end": {"value": self.end_node, "match_by": self.end_match_by},
+            "start": self.start.to_dict(),
+            "end": self.end.to_dict(),
         }
 
         # Only include properties if they exist and are not empty
@@ -205,21 +606,11 @@ class Edge(object):
 
             kind = edge_data["kind"]
 
-            # Handle different edge data formats
-            start_node = None
-            end_node = None
-            start_match_by = None
-            end_match_by = None
-
-            if "start" in edge_data and "end" in edge_data:
-                # Direct format: {"start": "id", "end": "id"}
-                start_node = edge_data["start"]["value"]
-                start_match_by = edge_data["start"]["match_by"]
-                end_node = edge_data["end"]["value"]
-                end_match_by = edge_data["end"]["match_by"]
-
-            if not start_node or not end_node:
+            if "start" not in edge_data or "end" not in edge_data:
                 return None
+
+            start = Endpoint.from_dict(edge_data["start"])
+            end = Endpoint.from_dict(edge_data["end"])
 
             properties_data = edge_data.get("properties", {})
 
@@ -230,29 +621,29 @@ class Edge(object):
                 for key, value in properties_data.items():
                     properties[key] = value
 
-            return cls(
-                start_node, end_node, kind, properties, start_match_by, end_match_by
-            )
+            return cls.with_endpoints(start, end, kind, properties)
         except (KeyError, TypeError, ValueError):
             return None
 
     def get_start_node(self) -> str:
         """
-        Get the start node ID.
+        Get the start endpoint value (the id or name; empty for property-matched
+        endpoints).
 
         Returns:
-          - str: Start node ID
+          - str: Start endpoint value
         """
-        return self.start_node
+        return self.start.value
 
     def get_end_node(self) -> str:
         """
-        Get the end node ID.
+        Get the end endpoint value (the id or name; empty for property-matched
+        endpoints).
 
         Returns:
-          - str: End node ID
+          - str: End endpoint value
         """
-        return self.end_node
+        return self.end.value
 
     def get_kind(self) -> str:
         """
@@ -270,11 +661,11 @@ class Edge(object):
         Returns:
           - str: Unique ID for the edge
         """
-        return f"[{self.start_match_by}:{self.start_node}]-({self.kind})->[{self.end_match_by}:{self.end_node}]"
+        return f"[{self.start.signature()}]-({self.kind})->[{self.end.signature()}]"
 
     def __eq__(self, other):
         """
-        Check if two edges are equal based on their start, end, and kind.
+        Check if two edges are equal based on their endpoints and kind.
 
         Args:
           - other (Edge): The other edge to compare to
@@ -284,22 +675,22 @@ class Edge(object):
         """
         if isinstance(other, Edge):
             return (
-                self.start_node == other.start_node
-                and self.end_node == other.end_node
-                and self.kind == other.kind
+                self.kind == other.kind
+                and self.start == other.start
+                and self.end == other.end
             )
         return False
 
     def __hash__(self):
         """
-        Hash based on start, end, and kind for use in sets and as dictionary keys.
+        Hash based on endpoints and kind for use in sets and as dictionary keys.
 
         Returns:
-          - int: Hash of the start, end, and kind
+          - int: Hash of the endpoints and kind
         """
-        return hash((self.start_node, self.end_node, self.kind))
+        return hash((self.start.signature(), self.end.signature(), self.kind))
 
-    def validate(self) -> tuple[bool, list[str]]:
+    def validate(self) -> tuple:
         """
         Validate the edge against the EDGE_SCHEMA.
 
@@ -308,32 +699,19 @@ class Edge(object):
         """
         errors = []
 
-        # Validate required fields
-        if not self.start_node or self.start_node is None:
-            errors.append("Start node cannot be empty")
-        elif not isinstance(self.start_node, str):
-            errors.append("Start node must be a string")
+        # Validate kind
+        kind_error = validate_kind(self.kind)
+        if kind_error:
+            errors.append(kind_error)
 
-        if not self.end_node or self.end_node is None:
-            errors.append("End node cannot be empty")
-        elif not isinstance(self.end_node, str):
-            errors.append("End node must be a string")
+        # Validate endpoints
+        is_start_valid, start_errors = self.start.validate()
+        if not is_start_valid:
+            errors.extend(f"Start endpoint: {e}" for e in start_errors)
 
-        if not self.kind or self.kind is None:
-            errors.append("Edge kind cannot be empty")
-        elif not isinstance(self.kind, str):
-            errors.append("Edge kind must be a string")
-
-        # Validate match_by values
-        if not isinstance(self.start_match_by, str):
-            errors.append("Start match_by must be a string")
-        elif self.start_match_by not in ["id", "name"]:
-            errors.append("Start match_by must be either 'id' or 'name'")
-
-        if not isinstance(self.end_match_by, str):
-            errors.append("End match_by must be a string")
-        elif self.end_match_by not in ["id", "name"]:
-            errors.append("End match_by must be either 'id' or 'name'")
+        is_end_valid, end_errors = self.end.validate()
+        if not is_end_valid:
+            errors.extend(f"End endpoint: {e}" for e in end_errors)
 
         # Validate properties if they exist
         if self.properties is not None:
@@ -347,4 +725,4 @@ class Edge(object):
         return len(errors) == 0, errors
 
     def __repr__(self) -> str:
-        return f"Edge(start='{self.start_node}', end='{self.end_node}', kind='{self.kind}', properties={self.properties})"
+        return f"Edge(start='{self.start.value}', end='{self.end.value}', kind='{self.kind}', properties={self.properties})"

--- a/bhopengraph/OpenGraph.py
+++ b/bhopengraph/OpenGraph.py
@@ -7,7 +7,7 @@
 import json
 from typing import Dict, List, Optional, Set
 
-from bhopengraph.Edge import Edge
+from bhopengraph.Edge import MATCH_BY_ID, Edge
 from bhopengraph.Node import Node
 
 
@@ -43,7 +43,11 @@ class OpenGraph(object):
     @staticmethod
     def _edge_key(edge: Edge) -> str:
         """
-        Generate a unique key for an edge based on start_node, end_node, and kind.
+        Generate a unique key for an edge based on its endpoints and kind.
+
+        The key incorporates each endpoint's match strategy (id, name, or
+        property matchers), so edges that differ only in how an endpoint is
+        resolved are not collapsed together.
 
         Args:
           - edge (Edge): Edge to generate key for
@@ -51,21 +55,25 @@ class OpenGraph(object):
         Returns:
           - str: Unique key for the edge
         """
-        return f"{edge.start_node}|{edge.end_node}|{edge.kind}"
+        return edge.get_unique_id()
 
     def add_edge(self, edge: Edge) -> bool:
         """
         Add an edge to the graph if it doesn't already exist and if the start and end nodes exist.
 
+        Only endpoints resolved by node id are checked against the local node
+        set; name- and property-matched endpoints are resolved by BloodHound at
+        ingestion time and cannot be validated here.
+
         Args:
           - edge (Edge): Edge to add
 
         Returns:
-          - bool: True if edge was added, False if start or end node doesn't exist
+          - bool: True if edge was added, False if an id-matched endpoint node doesn't exist
         """
-        if edge.start_node not in self.nodes:
+        if edge.start.match_by == MATCH_BY_ID and edge.start.value not in self.nodes:
             return False
-        if edge.end_node not in self.nodes:
+        if edge.end.match_by == MATCH_BY_ID and edge.end.value not in self.nodes:
             return False
 
         edge_key = self._edge_key(edge)
@@ -167,10 +175,28 @@ class OpenGraph(object):
             - List[Edge]: List of edges with no start or end node
         """
         return [
-            edge
-            for edge in self.edges.values()
-            if edge.start_node not in self.nodes or edge.end_node not in self.nodes
+            edge for edge in self.edges.values() if self._edge_has_missing_node(edge)
         ]
+
+    def _edge_has_missing_node(self, edge: Edge) -> bool:
+        """
+        Report whether an edge references a non-existent local node.
+
+        Only endpoints resolved by node id are checked; name- and
+        property-matched endpoints are resolved by BloodHound at ingestion time
+        and are not considered missing.
+
+        Args:
+          - edge (Edge): Edge to check
+
+        Returns:
+          - bool: True if an id-matched endpoint references a missing node
+        """
+        if edge.start.match_by == MATCH_BY_ID and edge.start.value not in self.nodes:
+            return True
+        if edge.end.match_by == MATCH_BY_ID and edge.end.value not in self.nodes:
+            return True
+        return False
 
     def get_isolated_edges_count(self) -> int:
         """
@@ -452,24 +478,29 @@ class OpenGraph(object):
         start_node_edges = {}
         end_node_edges = {}
 
-        # Build edge mappings and check for isolated edges
+        # Build edge mappings and check for isolated edges.
+        # Only id-matched endpoints reference local nodes; name- and
+        # property-matched endpoints are resolved by BloodHound at ingestion
+        # time and are not validated against the local node set.
         for edge_key, edge in self.edges.items():
-            # Check for isolated edges (edges referencing non-existent nodes)
-            if edge.start_node not in self.nodes:
+            start_is_id = edge.start.match_by == MATCH_BY_ID
+            end_is_id = edge.end.match_by == MATCH_BY_ID
+
+            if start_is_id and edge.start_node not in self.nodes:
                 errors.append(
                     f"Edge {edge_key} ({edge.start_node}->{edge.end_node}): Start node '{edge.start_node}' does not exist"
                 )
-            else:
+            elif start_is_id:
                 # Build start node mapping
                 if edge.start_node not in start_node_edges:
                     start_node_edges[edge.start_node] = []
                 start_node_edges[edge.start_node].append(edge)
 
-            if edge.end_node not in self.nodes:
+            if end_is_id and edge.end_node not in self.nodes:
                 errors.append(
                     f"Edge {edge_key} ({edge.start_node}->{edge.end_node}): End node '{edge.end_node}' does not exist"
                 )
-            else:
+            elif end_is_id:
                 # Build end node mapping
                 if edge.end_node not in end_node_edges:
                     end_node_edges[edge.end_node] = []

--- a/bhopengraph/__init__.py
+++ b/bhopengraph/__init__.py
@@ -12,7 +12,14 @@ that are compatible with BloodHound OpenGraph.
 """
 
 from .__version__ import __version__
-from .Edge import Edge
+from .Edge import (
+    MATCH_BY_ID,
+    MATCH_BY_NAME,
+    MATCH_BY_PROPERTY,
+    Edge,
+    Endpoint,
+    PropertyMatcher,
+)
 from .Node import Node
 from .OpenGraph import OpenGraph
 from .Properties import Properties
@@ -21,4 +28,14 @@ __version__
 
 __author__ = "Remi Gascou (@podalirius_)"
 
-__all__ = ["Properties", "Node", "Edge", "OpenGraph"]
+__all__ = [
+    "Properties",
+    "Node",
+    "Edge",
+    "Endpoint",
+    "PropertyMatcher",
+    "OpenGraph",
+    "MATCH_BY_ID",
+    "MATCH_BY_NAME",
+    "MATCH_BY_PROPERTY",
+]

--- a/bhopengraph/tests/test_Edge.py
+++ b/bhopengraph/tests/test_Edge.py
@@ -6,7 +6,14 @@ Test cases for the Edge class.
 
 import unittest
 
-from bhopengraph.Edge import Edge
+from bhopengraph.Edge import (
+    MATCH_BY_ID,
+    MATCH_BY_NAME,
+    MATCH_BY_PROPERTY,
+    Edge,
+    Endpoint,
+    PropertyMatcher,
+)
 from bhopengraph.Properties import Properties
 
 
@@ -167,6 +174,177 @@ class TestEdge(unittest.TestCase):
         self.assertIn("end_node", repr_str)
         self.assertIn("OWNS", repr_str)
         self.assertIn("Properties", repr_str)
+
+
+class TestEdgeKindValidation(unittest.TestCase):
+    """Test cases for edge kind validation (regex + reserved prefix)."""
+
+    def test_valid_kinds(self):
+        """Test that schema-compliant kinds are accepted."""
+        for kind in ["Knows", "CONNECTS_TO", "Okta_ResetPassword", "a1_B2"]:
+            with self.subTest(kind=kind):
+                edge = Edge("a", "b", kind)
+                self.assertEqual(edge.kind, kind)
+
+    def test_invalid_kinds_raise(self):
+        """Test that kinds with illegal characters or reserved prefix raise."""
+        invalid = [
+            "Has Access",  # space
+            "Reset-Password",  # hyphen
+            "Owns!",  # punctuation
+            "tag_custom",  # reserved tag_ prefix
+            "TAG_Custom",  # reserved prefix, uppercase
+            "Tag_Custom",  # reserved prefix, mixed case
+        ]
+        for kind in invalid:
+            with self.subTest(kind=kind):
+                with self.assertRaises(ValueError):
+                    Edge("a", "b", kind)
+
+
+class TestPropertyMatcher(unittest.TestCase):
+    """Test cases for the PropertyMatcher class."""
+
+    def test_to_dict(self):
+        """Test serialization of a property matcher."""
+        matcher = PropertyMatcher(key="username", value="alice.smith")
+        self.assertEqual(
+            matcher.to_dict(),
+            {"key": "username", "operator": "equals", "value": "alice.smith"},
+        )
+
+    def test_validate_requires_key(self):
+        """Test that a matcher without a key is invalid."""
+        is_valid, _ = PropertyMatcher(key="", value="x").validate()
+        self.assertFalse(is_valid)
+
+    def test_equality(self):
+        """Test matcher equality and hashing."""
+        a = PropertyMatcher("k", "v")
+        b = PropertyMatcher("k", "v")
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+
+
+class TestEndpoint(unittest.TestCase):
+    """Test cases for the Endpoint class and match_by strategies."""
+
+    def test_by_id(self):
+        """Test an id-matched endpoint serializes to value + match_by."""
+        ep = Endpoint.by_id("server-1")
+        self.assertEqual(ep.to_dict(), {"match_by": "id", "value": "server-1"})
+
+    def test_by_name_with_kind(self):
+        """Test a name-matched endpoint includes the kind filter."""
+        ep = Endpoint.by_name("alice", "User")
+        self.assertEqual(
+            ep.to_dict(), {"match_by": "name", "value": "alice", "kind": "User"}
+        )
+        self.assertNotIn("property_matchers", ep.to_dict())
+
+    def test_by_property(self):
+        """Test a property-matched endpoint serializes property_matchers."""
+        matchers = [
+            PropertyMatcher("username", "alice.smith"),
+            PropertyMatcher("active", True),
+        ]
+        ep = Endpoint.by_property(matchers, "User")
+        d = ep.to_dict()
+        self.assertEqual(d["match_by"], "property")
+        self.assertEqual(d["kind"], "User")
+        self.assertNotIn("value", d)
+        self.assertEqual(len(d["property_matchers"]), 2)
+        self.assertEqual(
+            d["property_matchers"][0],
+            {"key": "username", "operator": "equals", "value": "alice.smith"},
+        )
+
+    def test_validate_id_requires_value(self):
+        """Test that an id endpoint with no value is invalid."""
+        is_valid, _ = Endpoint.by_id("").validate()
+        self.assertFalse(is_valid)
+
+    def test_validate_property_requires_matcher(self):
+        """Test that a property endpoint with no matchers is invalid."""
+        is_valid, _ = Endpoint.by_property([], "User").validate()
+        self.assertFalse(is_valid)
+
+    def test_validate_property_matcher_requires_key(self):
+        """Test that a property matcher with an empty key is invalid."""
+        ep = Endpoint.by_property([PropertyMatcher("", "x")], "")
+        is_valid, _ = ep.validate()
+        self.assertFalse(is_valid)
+
+    def test_constants(self):
+        """Test the exported match_by constants."""
+        self.assertEqual(MATCH_BY_ID, "id")
+        self.assertEqual(MATCH_BY_NAME, "name")
+        self.assertEqual(MATCH_BY_PROPERTY, "property")
+
+
+class TestEdgeWithEndpoints(unittest.TestCase):
+    """Test cases for Edge.with_endpoints and round-tripping."""
+
+    def test_match_by_name(self):
+        """Test building an edge whose endpoints match by name."""
+        edge = Edge.with_endpoints(
+            Endpoint.by_name("alice", "User"),
+            Endpoint.by_name("file-server-1", "Server"),
+            "HasAccess",
+        )
+        d = edge.to_dict()
+        self.assertEqual(d["start"]["match_by"], "name")
+        self.assertEqual(d["start"]["value"], "alice")
+        self.assertEqual(d["start"]["kind"], "User")
+
+    def test_match_by_property(self):
+        """Test building an edge with a property-matched start endpoint."""
+        matchers = [PropertyMatcher("username", "alice.smith")]
+        edge = Edge.with_endpoints(
+            Endpoint.by_property(matchers, "User"),
+            Endpoint.by_id("server-1"),
+            "CustomRelationship",
+        )
+        d = edge.to_dict()
+        self.assertEqual(d["start"]["match_by"], "property")
+        self.assertNotIn("value", d["start"])
+        self.assertEqual(d["end"], {"match_by": "id", "value": "server-1"})
+
+    def test_from_dict_property_matchers(self):
+        """Test that from_dict reconstructs a property-matched endpoint."""
+        edge_data = {
+            "kind": "CustomRelationship",
+            "start": {
+                "match_by": "property",
+                "kind": "User",
+                "property_matchers": [
+                    {"key": "username", "operator": "equals", "value": "alice.smith"}
+                ],
+            },
+            "end": {"match_by": "id", "value": "server-1"},
+        }
+        edge = Edge.from_dict(edge_data)
+        self.assertIsNotNone(edge)
+        self.assertEqual(edge.start.match_by, "property")
+        self.assertEqual(len(edge.start.property_matchers), 1)
+        self.assertEqual(edge.start.property_matchers[0].key, "username")
+        # Round-trips back to the same shape.
+        self.assertEqual(edge.to_dict()["start"], edge_data["start"])
+
+    def test_equal_across_match_strategies(self):
+        """Test that edges differing only in match strategy are not equal."""
+        by_id = Edge("a", "b", "K")
+        by_name = Edge.with_endpoints(
+            Endpoint.by_name("a", ""), Endpoint.by_id("b"), "K"
+        )
+        self.assertNotEqual(by_id, by_name)
+
+    def test_invalid_property_endpoint_raises(self):
+        """Test that an edge with an invalid property endpoint raises."""
+        with self.assertRaises(ValueError):
+            Edge.with_endpoints(
+                Endpoint.by_property([], "User"), Endpoint.by_id("b"), "K"
+            )
 
 
 if __name__ == "__main__":

--- a/bhopengraph/tests/test_OpenGraph.py
+++ b/bhopengraph/tests/test_OpenGraph.py
@@ -366,10 +366,7 @@ class TestOpenGraph(unittest.TestCase):
         is_valid, errors = self.graph.validate_graph()
         self.assertFalse(is_valid)
         self.assertTrue(
-            any(
-                "Start match_by must be either 'id' or 'name'" in error
-                for error in errors
-            )
+            any("Unsupported match_by 'invalid'" in error for error in errors)
         )
 
     def test_validate_graph_with_valid_graph(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
 [tool.poetry.scripts]
 bhopengraph = "bhopengraph.__main__:main"
 
+[tool.isort]
+profile = "black"
+
 [build-system]
 requires = ["poetry-core>=1.7.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
### Linked Issue
Closes #12

### Root Cause
The `Edge` class predates the structured-graph additions to the BloodHound OpenGraph edge schema. It validated `kind` only for non-emptiness — never against the schema's allowed character set (`^[A-Za-z0-9_]+$`) or its reserved `tag_` prefix — so kinds containing spaces or punctuation, or using the reserved prefix, were accepted and would be rejected by BloodHound at ingest. Endpoints were hard-coded to the `id`/`name` strategies with no support for the schema's `property` match strategy (`property_matchers`) or the optional per-endpoint `kind` filter.

### Fix Description
- **Kind validation:** a `validate_kind()` helper enforces `^[A-Za-z0-9_]+$` and rejects the case-insensitive `tag_` prefix; it is applied in the constructor and in `validate()`.
- **Endpoint model:** new `Endpoint` and `PropertyMatcher` classes model the three match strategies (`id`, `name`, `property`) plus an optional `kind` filter, each with validation and schema-correct `to_dict()` / `from_dict()` serialization (`value` for id/name, `property_matchers` for property). Constants `MATCH_BY_ID` / `MATCH_BY_NAME` / `MATCH_BY_PROPERTY` are exported.
- **Edge:** a new `Edge.with_endpoints()` constructor accepts explicit endpoints; the existing `Edge(start, end, kind, ..., start_match_by, end_match_by)` signature is preserved via `start_node` / `end_node` / `start_match_by` / `end_match_by` properties, so existing callers are unaffected. Equality and the dedup key now incorporate the full match strategy.
- **OpenGraph:** node-existence checks in `add_edge()`, `validate_graph()`, and `get_isolated_edges()` now apply only to `id`-matched endpoints — `name`/`property` endpoints are resolved by BloodHound at ingest and cannot be validated locally.

This brings the Python library to parity with the Go implementation (`gopengraph`). The `EDGE_SCHEMA` and documentation links are updated to the OpenGraph developer docs.

### How Verified
- Before: `Edge("a","b","Has Access!")` and `Edge("a","b","tag_custom")` constructed successfully. After: both raise `ValueError`.
- Round-trip: an edge with a `property`-matched start endpoint exports to the schema-defined `property_matchers` shape and re-imports identically (`from_dict`).
- An end-to-end graph mixing `id`-, `name`-, and `property`-matched edges exports valid JSON and passes `validate_graph()`.
- Full test suite: 199 passed.

### Test Coverage
**Added:** `bhopengraph/tests/test_Edge.py`
- `TestEdgeKindValidation` — accepts schema-valid kinds; rejects spaces, hyphens, punctuation, and `tag_`/`TAG_`/`Tag_` prefixes.
- `TestPropertyMatcher`, `TestEndpoint` — serialization, validation, and the `id`/`name`/`property` strategies.
- `TestEdgeWithEndpoints` — name/property edges, `from_dict` round-trip, equality across match strategies, invalid-endpoint rejection.

`bhopengraph/tests/test_OpenGraph.py` updated for the new endpoint validation message.

### Scope of Change
- **Files changed:** `bhopengraph/Edge.py`, `bhopengraph/OpenGraph.py`, `bhopengraph/__init__.py`, `bhopengraph/tests/test_Edge.py`, `bhopengraph/tests/test_OpenGraph.py`, `README.md`, `pyproject.toml`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** the only adjacent change is adding `[tool.isort] profile = "black"` to `pyproject.toml` so `isort` and `black` agree on the multi-symbol import introduced in the new tests; existing single-line imports are unaffected.

### Risk and Rollout
The legacy `Edge(...)` constructor is unchanged, so existing collectors continue to work. New behavior: previously-accepted invalid edge kinds now raise `ValueError` — the intended schema-conforming behavior. Self-contained; safe to merge.

### Notes
Closely related to #10 and #11 (other OpenGraph schema-conformance fixes); `PropertyMatcher` validation reuses the `primitive_category()` helper introduced in #10.
