### PR TITLE
Release v1.4.0

### DIFF
--- a/bhopengraph/__version__.py
+++ b/bhopengraph/__version__.py
@@ -5,4 +5,4 @@
 # Date created       : 04 Feb 2026
 
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bhopengraph"
-version = "1.3.1"
+version = "1.4.0"
 description = "A python library to create BloodHound OpenGraphs easily"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ with open('requirements.txt', 'r', encoding='utf-8') as f:
 
 setuptools.setup(
     name="bhopengraph",
-    version="1.3.1",
+    version="1.4.0",
     description="A python library to create BloodHound OpenGraphs easily",
     url="https://github.com/p0dalirius/bhopengraph",
     author="Podalirius",


### PR DESCRIPTION
### Summary
Version bump to `v1.4.0`, releasing the OpenGraph edge/node/property schema-conformance changes merged in #13, #14, and #15.

### Changes since v1.3.1
- Reject `null` property values and arrays mixing the `number` and `boolean` categories (#10 / #13).
- Reject construction of nodes with more than three kinds (#11 / #14).
- Validate edge `kind` against `^[A-Za-z0-9_]+$` and the reserved `tag_` prefix, and add the `property` endpoint match strategy with per-endpoint `kind` filters (#12 / #15).

### Scope of Change
- **Files changed:** `bhopengraph/__version__.py`, `pyproject.toml`, `setup.py`
- **Submodule pointer updated:** no
- **Behavioral changes:** none (version metadata only)

### Notes
This release contains behavioral changes that may affect existing callers (a property value of `None` and over-limit node kinds now raise `ValueError`); the minor version is bumped accordingly.
